### PR TITLE
Set the content_type of JSONResponse objects to application/json

### DIFF
--- a/fhurl.py
+++ b/fhurl.py
@@ -33,7 +33,7 @@ class JSONResponse(HttpResponse):
     def __init__(self, data):
         HttpResponse.__init__(
             self, content=json.dumps(data, cls=JSONEncoder),
-            #mimetype="text/html",
+            content_type="application/json"
         ) 
 # }}}
 


### PR DESCRIPTION
... RFC4627. This helps Ajax libraries like jQuery to automatically parse responses as JSON
